### PR TITLE
Add a force Option to allow the build to continue

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -7,7 +7,8 @@ module.exports = grunt => {
 		const opts = this.options({
 			outputFile: false,
 			quiet: false,
-			maxWarnings: -1
+			maxWarnings: -1,
+			force: false
 		});
 
 		if (this.filesSrc.length === 0) {
@@ -56,6 +57,6 @@ module.exports = grunt => {
 			grunt.warn(`ESLint found too many warnings (maximum: ${opts.maxWarnings})`);
 		}
 
-		return report.errorCount === 0;
+		return opts.force ? 0 : report.errorCount === 0;
 	});
 };


### PR DESCRIPTION
In my use case for grunt scripts we need to have the ability to generate all the errors for our different modules separately. Currently in the existing framework if one module has one error it stops the whole build and we get zero feedback and visibility into the errors for other modules.